### PR TITLE
feat: upgrade to postgres 17

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install poetry \
     && apt update \
     && apt install -y postgresql-common \
     && yes | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh \
-    && apt install -y postgresql-client-16
+    && apt install -y postgresql-client-17
 
 # Workaround to add bind mount on fargate launch type which doesn't support tmpfs:
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html


### PR DESCRIPTION
Closes https://github.com/OrcaBus/wiki/issues/82

Update to postgres 17 as pg_dump/pg_restore will fail if the major version is not the same.